### PR TITLE
Update logrotate rule for ubuntu 16.06

### DIFF
--- a/files/etc/logrotate.d/rsyslog
+++ b/files/etc/logrotate.d/rsyslog
@@ -8,7 +8,7 @@
 	compress
   create 640 syslog adm
 	postrotate
-		reload rsyslog >/dev/null 2>&1 || true
+		service rsyslog rotate >/dev/null 2>&1 || true
 	endscript
 }
 
@@ -33,6 +33,6 @@
 	delaycompress
 	sharedscripts
 	postrotate
-		reload rsyslog >/dev/null 2>&1 || true
+		service rsyslog rotate >/dev/null 2>&1 || true
 	endscript
 }


### PR DESCRIPTION
the reload command doesn't exist in ubuntu 16.04 anymore
