### PR TITLE
Convert Modulefile to metadata.json.

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,7 +1,0 @@
-name 'rodjek-logrotate'
-version '1.1.1'
-source 'https://github.com/rodjek/puppet-logrotate'
-license 'MIT'
-summary 'Logrotate module'
-description 'Manage logrotate on your servers with Puppet'
-project_page 'https://github.com/rodjek/puppet-logrotate'

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,53 @@
+{
+  "name": "skyscrapers-logrotate",
+  "version": "1.1.1",
+  "summary": "Manage logrotate",
+  "license": "MIT",
+  "source": "https://github.com/skyscrapers/puppet-logrotate",
+  "project_page": "https://github.com/skyscrapers/puppet-logrotate",
+  "issues_url": "https://github.com/skyscrapers/puppet-logrotate/issues",
+  "tags": [
+    "logrotate"
+  ],
+  "dependencies": [
+    {
+      "name": "puppetlabs/stdlib",
+      "version_requirement": ">= 1.0.0 <5.0.0"
+    }
+  ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">= 3.2.0 < 5.0.0"
+    },
+    {
+      "name": "pe",
+      "version_requirement": ">= 3.2.0 < 2015.4.0"
+    }
+  ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "5",
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": [
+        "10.04",
+        "12.04",
+        "14.04"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Converting the old Puppet `Modulefile` to the newer `metadata.json` setup. This change is currently needed to work with the test setup being put in place for `puppet-customer`. The dependency manager `librarian-puppet` barfs on the Modulefile in this repo. Repo's having a `metadata.json` work correctly.